### PR TITLE
Add list_s3_buckets tool and update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# awschatbot
+# AWS Chatbot
+
+This project provides a simple natural language chatbot that can answer questions about your AWS account using the LangChain framework.
+
+## Features
+
+The chatbot exposes custom tools backed by boto3 for:
+
+- Counting the number of S3 buckets that are publicly accessible.
+- Listing all S3 buckets in the account.
+- Listing example objects in a specific S3 bucket.
+- Finding the instance type of an EC2 instance by IP address.
+- Listing IAM policies attached to a given user.
+
+These tools are combined with an OpenAI chat model via LangChain's function calling agent to allow natural language interaction.
+
+## Usage
+
+1. Install dependencies (requires Python 3.12 or later):
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Export your AWS credentials and an OpenAI API key:
+
+```bash
+export AWS_ACCESS_KEY_ID=...  # or configure using any AWS method
+export AWS_SECRET_ACCESS_KEY=...
+export OPENAI_API_KEY=...
+```
+
+3. Run the chatbot:
+
+```bash
+python -m awschatbot.chatbot
+```
+
+You can then ask questions such as:
+
+- "How many S3 buckets are exposed to the public?"
+- "List all S3 buckets in the account."
+- "What data does the S3 bucket my-bucket hold?"
+- "What is the size of the EC2 instance with IP 1.2.3.4?"
+- "What permissions does the user alice have?"
+
+Note that the tools rely on boto3 and therefore require access credentials with appropriate permissions.

--- a/awschatbot/aws_tools.py
+++ b/awschatbot/aws_tools.py
@@ -1,0 +1,104 @@
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+from langchain.tools import tool
+from typing import Optional
+
+
+def _s3_client():
+    return boto3.client("s3")
+
+
+def _ec2_client():
+    return boto3.client("ec2")
+
+
+def _iam_client():
+    return boto3.client("iam")
+
+
+@tool("count_public_s3_buckets")
+def count_public_s3_buckets() -> str:
+    """Return the number of S3 buckets that are publicly accessible."""
+    s3 = _s3_client()
+    try:
+        response = s3.list_buckets()
+    except (BotoCoreError, ClientError) as e:
+        return f"Failed to list buckets: {e}"
+
+    buckets = response.get("Buckets", [])
+    public_buckets = []
+    for b in buckets:
+        name = b["Name"]
+        try:
+            acl = s3.get_bucket_acl(Bucket=name)
+        except ClientError as e:
+            continue
+        for grant in acl.get("Grants", []):
+            grantee = grant.get("Grantee", {})
+            uri = grantee.get("URI", "")
+            if "AllUsers" in uri or "AuthenticatedUsers" in uri:
+                public_buckets.append(name)
+                break
+    return str(len(public_buckets))
+
+
+@tool("list_s3_buckets")
+def list_s3_buckets() -> str:
+    """Return a list of all S3 buckets in the account."""
+    s3 = _s3_client()
+    try:
+        response = s3.list_buckets()
+    except (BotoCoreError, ClientError) as e:
+        return f"Failed to list buckets: {e}"
+
+    bucket_names = [b["Name"] for b in response.get("Buckets", [])]
+    if not bucket_names:
+        return "No buckets found."
+    return "\n".join(bucket_names)
+
+
+@tool("describe_bucket_contents")
+def describe_bucket_contents(bucket: str) -> str:
+    """Return a short description of the objects stored in the S3 bucket."""
+    s3 = _s3_client()
+    try:
+        response = s3.list_objects_v2(Bucket=bucket, MaxKeys=5)
+    except (BotoCoreError, ClientError) as e:
+        return f"Failed to list contents of {bucket}: {e}"
+    contents = response.get("Contents", [])
+    if not contents:
+        return f"Bucket {bucket} is empty."
+    keys = [obj["Key"] for obj in contents]
+    return "\n".join(keys)
+
+
+@tool("ec2_instance_type_by_ip")
+def ec2_instance_type_by_ip(ip: str) -> str:
+    """Given an IP address, return the instance type of the EC2 instance."""
+    ec2 = _ec2_client()
+    try:
+        resp = ec2.describe_instances(
+            Filters=[{"Name": "ip-address", "Values": [ip]}, {"Name": "private-ip-address", "Values": [ip]}]
+        )
+    except (BotoCoreError, ClientError) as e:
+        return f"Failed to describe instances: {e}"
+    for reservation in resp.get("Reservations", []):
+        for inst in reservation.get("Instances", []):
+            return inst.get("InstanceType", "unknown")
+    return "Instance not found"
+
+
+@tool("describe_user_permissions")
+def describe_user_permissions(user: str) -> str:
+    """Return list of attached IAM policies for the given user."""
+    iam = _iam_client()
+    try:
+        attached = iam.list_attached_user_policies(UserName=user)
+        inline = iam.list_user_policies(UserName=user)
+    except (BotoCoreError, ClientError) as e:
+        return f"Failed to describe user {user}: {e}"
+    policies = [p["PolicyName"] for p in attached.get("AttachedPolicies", [])]
+    policies.extend(inline.get("PolicyNames", []))
+    if not policies:
+        return f"User {user} has no policies."
+    return "\n".join(policies)

--- a/awschatbot/chatbot.py
+++ b/awschatbot/chatbot.py
@@ -1,0 +1,35 @@
+"""Simple AWS chatbot using LangChain tools."""
+
+from langchain.agents import initialize_agent, AgentType
+from langchain_community.chat_models import ChatOpenAI
+from . import aws_tools
+
+
+def create_agent() -> "AgentExecutor":
+    llm = ChatOpenAI(temperature=0)
+    tools = [
+        aws_tools.count_public_s3_buckets,
+        aws_tools.list_s3_buckets,
+        aws_tools.describe_bucket_contents,
+        aws_tools.ec2_instance_type_by_ip,
+        aws_tools.describe_user_permissions,
+    ]
+    return initialize_agent(tools, llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=True)
+
+
+def main() -> None:
+    agent = create_agent()
+    print("AWS Chatbot. Type 'quit' to exit.")
+    while True:
+        try:
+            query = input("> ")
+        except EOFError:
+            break
+        if not query or query.lower() in {"quit", "exit"}:
+            break
+        result = agent.run(query)
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+boto3
+langchain
+langchain-community
+openai


### PR DESCRIPTION
## Summary
- implement `list_s3_buckets` tool for enumerating S3 buckets
- include the new tool in the chatbot agent
- use `langchain_community` ChatOpenAI import
- document installation using `requirements.txt`
- add `requirements.txt` listing langchain-community

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68822102223883278e612fd892a19fab